### PR TITLE
fix safepublish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@benglynn/press",
-  "version": "1.2.0-benglynn.0",
+  "version": "1.2.0-benglynn.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@benglynn/press",
-  "version": "1.1.0",
+  "version": "1.2.0-benglynn.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -530,7 +530,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.6.tgz",
       "integrity": "sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==",
-      "dev": true,
       "optional": true,
       "requires": {
         "good-listener": "^1.2.2",
@@ -664,7 +663,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
       "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "dev": true,
       "optional": true
     },
     "diff": {
@@ -1061,7 +1059,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "dev": true,
       "optional": true,
       "requires": {
         "delegate": "^3.1.2"
@@ -1761,7 +1758,6 @@
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.20.0.tgz",
       "integrity": "sha512-AEDjSrVNkynnw6A+B1DsFkd6AVdTnp+/WoUixFRULlCLZVRZlVQMVWio/16jv7G1FscUxQxOQhWwApgbnxr6kQ==",
-      "dev": true,
       "requires": {
         "clipboard": "^2.0.0"
       }
@@ -1993,7 +1989,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "dev": true,
       "optional": true
     },
     "semver": {
@@ -2226,7 +2221,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "dev": true,
       "optional": true
     },
     "to-fast-properties": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "html-minifier": "^4.0.0",
     "js-yaml": "^3.14.0",
     "pug": "^3.0.0",
-    "showdown": "^1.9.1"
+    "showdown": "^1.9.1",
+    "prismjs": "^1.20.0"
   },
   "devDependencies": {
     "@benglynn/publish": "^1.0.6",
@@ -52,7 +53,6 @@
     "eslint-plugin-prettier": "^3.1.4",
     "mocha": "^8.0.1",
     "prettier": "^2.0.5",
-    "prismjs": "^1.20.0",
     "ts-node": "^8.10.2",
     "typescript": "^3.9.6"
   }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "types": "dist/api.d.ts",
   "scripts": {
     "prepublishOnly": "npm run build",
-    "publish": "safepublish",
+    "safepublish": "safepublish",
     "build": "rm -r ./dist/* & tsc",
     "lint": "eslint src",
     "test": "npx mocha --require ts-node/register --extensions ts,tsx --watch-files src,test 'test/**/*.{ts,tsx}'"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@benglynn/press",
-  "version": "1.1.0",
+  "version": "1.2.0-benglynn.0",
   "engines": {
     "node": ">=12.16.3"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@benglynn/press",
-  "version": "1.2.0-benglynn.0",
+  "version": "1.2.0-benglynn.1",
   "engines": {
     "node": ">=12.16.3"
   },


### PR DESCRIPTION
Resolve issue (caused by a naming collision) where npm publish fires twice. Validate this against press-demo and fix any dependency issues.